### PR TITLE
Improve code readability

### DIFF
--- a/src/main/java/pixel/command/Command.java
+++ b/src/main/java/pixel/command/Command.java
@@ -3,7 +3,6 @@ package pixel.command;
 import pixel.task.TaskList;
 import pixel.util.PixelException;
 import pixel.util.Storage;
-import pixel.util.Ui;
 
 /**
  * Represents the structure of a Command entered by the user, which performs a function when executed.

--- a/src/main/java/pixel/command/ExitCommand.java
+++ b/src/main/java/pixel/command/ExitCommand.java
@@ -16,6 +16,6 @@ public class ExitCommand extends Command {
      */
     @Override
     public String execute(TaskList taskList, Storage storage) {
-        return " Goodbye. Hope to see you again soon!";
+        return Ui.EXIT;
     }
 }

--- a/src/main/java/pixel/task/Task.java
+++ b/src/main/java/pixel/task/Task.java
@@ -29,6 +29,10 @@ public abstract class Task {
         this.isDone = false;
     }
 
+    public boolean isDone() {
+        return this.isDone;
+    }
+
     @Override
     public String toString() {
         return this.getStatusIcon() + " " + this.desc;

--- a/src/main/java/pixel/task/Task.java
+++ b/src/main/java/pixel/task/Task.java
@@ -29,7 +29,6 @@ public abstract class Task {
         this.isDone = false;
     }
 
-
     @Override
     public String toString() {
         return this.getStatusIcon() + " " + this.desc;

--- a/src/main/java/pixel/task/TaskList.java
+++ b/src/main/java/pixel/task/TaskList.java
@@ -36,7 +36,9 @@ public class TaskList {
      * @return The Task which was added
      */
     public Task addTask(Task task) {
+        int originalSize = this.contents.size();
         this.contents.add(task);
+        assert this.contents.size() == originalSize + 1 : "Size of taskList should have incremented by 1";
         return task;
     }
 
@@ -53,6 +55,7 @@ public class TaskList {
             throw new PixelException("Please input a valid task number!");
         }
         this.contents.get(idx).markTask();
+        assert this.contents.get(idx).isDone() : "Task should be marked as done";
         return this.contents.get(idx);
     }
 
@@ -69,6 +72,7 @@ public class TaskList {
             throw new PixelException("Please input a valid task number!");
         }
         this.contents.get(idx).unmarkTask();
+        assert !this.contents.get(idx).isDone() : "Task should be marked as not done";
         return this.contents.get(idx);
     }
 

--- a/src/main/java/pixel/task/TaskList.java
+++ b/src/main/java/pixel/task/TaskList.java
@@ -48,7 +48,8 @@ public class TaskList {
      * @throws PixelException If the index provided does not correspond to a Task
      */
     public Task markTask(int idx) throws PixelException {
-        if (idx < 0 || idx >= this.contents.size() || this.contents.get(idx) == null) {
+        boolean indexOutOfRange = idx < 0 || idx >= this.contents.size();
+        if (indexOutOfRange || this.contents.get(idx) == null) {
             throw new PixelException("Please input a valid task number!");
         }
         this.contents.get(idx).markTask();
@@ -63,7 +64,8 @@ public class TaskList {
      * @throws PixelException If the index provided does not correspond to a Task
      */
     public Task unmarkTask(int idx) throws PixelException {
-        if (idx < 0 || idx >= this.contents.size() || this.contents.get(idx) == null) {
+        boolean indexOutOfRange = idx < 0 || idx >= this.contents.size();
+        if (indexOutOfRange || this.contents.get(idx) == null) {
             throw new PixelException("Please input a valid task number!");
         }
         this.contents.get(idx).unmarkTask();
@@ -78,7 +80,8 @@ public class TaskList {
      * @throws PixelException If the index provided does not correspond to a Task
      */
     public Task deleteTask(int idx) throws PixelException {
-        if (idx < 0 || idx >= this.contents.size() || this.contents.get(idx) == null) {
+        boolean indexOutOfRange = idx < 0 || idx >= this.contents.size();
+        if (indexOutOfRange || this.contents.get(idx) == null) {
             throw new PixelException("Please input a valid task number!");
         }
         return this.contents.remove(idx);

--- a/src/main/java/pixel/util/Parser.java
+++ b/src/main/java/pixel/util/Parser.java
@@ -31,8 +31,10 @@ public class Parser {
         if (comp.length > 2) {
             throw new PixelException("Please use the format YYYY-MM-DD HH:MM for the date and time!");
         }
+
         try {
             if (comp.length == 1) {
+                // If time not provided, it is assumed to be 00:00
                 return LocalDateTime.parse(comp[0] + "T00:00");
             }
             return LocalDateTime.parse(comp[0] + "T" + comp[1]);
@@ -51,13 +53,16 @@ public class Parser {
      */
     public static String[] parseToDo(String[] commandComponents) throws PixelException {
         StringBuilder desc = new StringBuilder();
+
         for (int i = 1; i < commandComponents.length; i++) {
             desc.append(commandComponents[i]).append(" ");
         }
+
         if (desc.toString().isEmpty()) {
             throw new PixelException("Please include a description for the ToDo!");
         }
-        return new String[]{desc.toString().strip()};
+
+        return new String[] { desc.toString().strip() };
     }
 
     /**
@@ -69,28 +74,25 @@ public class Parser {
      * @throws PixelException If the task details required for a Deadline task are missing or invalid
      */
     public static String[] parseDeadline(String[] commandComponents) throws PixelException {
-        int i = 1;
         StringBuilder desc = new StringBuilder();
         StringBuilder dueBy = new StringBuilder();
-        while (i < commandComponents.length) {
+        StringBuilder pointer = desc;
+
+        for (int i = 1; i < commandComponents.length; i++) {
             if (commandComponents[i].equals("/by")) {
-                i++;
-                break;
+                pointer = dueBy;
             } else {
-                desc.append(commandComponents[i]).append(" ");
-                i++;
+                pointer.append(commandComponents[i]).append(" ");
             }
         }
-        while (i < commandComponents.length) {
-            dueBy.append(commandComponents[i]).append(" ");
-            i++;
-        }
+
         if (desc.toString().isEmpty()) {
             throw new PixelException("Please include a description for the Deadline!");
         } else if (dueBy.toString().isEmpty()) {
             throw new PixelException("Please set a deadline using '/by' followed by a date/time!");
         }
-        return new String[]{desc.toString().strip(), dueBy.toString().strip()};
+
+        return new String[] { desc.toString().strip(), dueBy.toString().strip() };
     }
 
     /**
@@ -102,32 +104,21 @@ public class Parser {
      * @throws PixelException If the task details required for an Event task are missing or invalid
      */
     public static String[] parseEvent(String[] commandComponents) throws PixelException {
-        int i = 1;
         StringBuilder desc = new StringBuilder();
         StringBuilder from = new StringBuilder();
         StringBuilder to = new StringBuilder();
-        while (i < commandComponents.length) {
+        StringBuilder pointer = desc;
+
+        for (int i = 1; i < commandComponents.length; i++) {
             if (commandComponents[i].equals("/from")) {
-                i++;
-                break;
+                pointer = from;
+            } else if (commandComponents[i].equals("/to")) {
+                pointer = to;
             } else {
-                desc.append(commandComponents[i]).append(" ");
-                i++;
+                pointer.append(commandComponents[i]).append(" ");
             }
         }
-        while (i < commandComponents.length) {
-            if (commandComponents[i].equals("/to")) {
-                i++;
-                break;
-            } else {
-                from.append(commandComponents[i]).append(" ");
-                i++;
-            }
-        }
-        while (i < commandComponents.length) {
-            to.append(commandComponents[i]).append(" ");
-            i++;
-        }
+
         if (desc.toString().isEmpty()) {
             throw new PixelException("Please include a description for the Event!");
         } else if (from.toString().isEmpty()) {
@@ -135,7 +126,8 @@ public class Parser {
         } else if (to.toString().isEmpty()) {
             throw new PixelException("Please set a ending date/time using '/to' followed by a date/time!");
         }
-        return new String[]{desc.toString().strip(), from.toString().strip(), to.toString().strip()};
+
+        return new String[] { desc.toString().strip(), from.toString().strip(), to.toString().strip() };
     }
 
     /**

--- a/src/main/java/pixel/util/Storage.java
+++ b/src/main/java/pixel/util/Storage.java
@@ -41,9 +41,6 @@ public class Storage {
         String keyword;
         String desc;
         String isDone;
-        String dueBy;
-        String from;
-        String to;
         try {
             File file = new File(this.filePath);
             Scanner sc = new Scanner(file);
@@ -58,14 +55,14 @@ public class Storage {
                 case "deadline":
                     desc = sc.nextLine();
                     isDone = sc.nextLine();
-                    dueBy = sc.nextLine();
+                    String dueBy = sc.nextLine();
                     taskList.addTask(new Deadline(desc, Boolean.parseBoolean(isDone), LocalDateTime.parse(dueBy)));
                     continue;
                 case "event":
                     desc = sc.nextLine();
                     isDone = sc.nextLine();
-                    from = sc.nextLine();
-                    to = sc.nextLine();
+                    String from = sc.nextLine();
+                    String to = sc.nextLine();
                     taskList.addTask(new Event(desc, Boolean.parseBoolean(isDone),
                             LocalDateTime.parse(from), LocalDateTime.parse(to)));
                     continue;


### PR DESCRIPTION
Some of the condition checks are overly complicated and
some methods in Parser class are too long

This unnecessary complexity makes the code harder to read

Let's refactor the code by abstracting out some of the condition checks
and change how the long methods are implemented to avoid duplicating code

This will make the code more readable for future maintainers